### PR TITLE
add unselect tag filter

### DIFF
--- a/frontend/src/components/HomeScreen/FeaturedPlaylists/FeaturedPlaylists.js
+++ b/frontend/src/components/HomeScreen/FeaturedPlaylists/FeaturedPlaylists.js
@@ -26,8 +26,8 @@ function FeaturedPlaylists({
   const classes = useStyles();
   const [feedItems, setFeedItems] = React.useState([]);
   const [loading, setLoading] = React.useState([]);
-  const [tags, setTag] = React.useState("");
-
+  const [tags, setTag] = React.useState("No Tag");
+  
   React.useEffect(() => {
     (async () => {
       setLoading(true);
@@ -67,6 +67,7 @@ function FeaturedPlaylists({
             value={tags}
             onChange={(e) => setTag(e.target.value)}
           >
+            <MenuItem value="No Tag">No Tag</MenuItem>
             {listOfTag.map((tag, index) => {
               return (
                 <MenuItem key={index} value={tag}>
@@ -78,7 +79,7 @@ function FeaturedPlaylists({
 
           <Grid container direction="column" spacing={1}>
             {feedItems.map((playlist) => {
-              if (!tags || (playlist.tags && playlist.tags.includes(tags))) {
+              if (tags === "No Tag" || (playlist.tags && playlist.tags.includes(tags))) {
                 return (
                   <FeedItem
                     key={playlist.id}


### PR DESCRIPTION
No tag select item is initialized in the react hook. Added no material ui menuItem for No Tag which always renders. When tags is set to No Tag no filter is applied.

Note: The tags functionality will break if a tag happens to be called "No Tag" let me know if you want me to update the code to change the No Tag value to some kind of hash.

Image (intial page looks like):
![image](https://user-images.githubusercontent.com/58538645/100985571-27516680-351a-11eb-811b-f776c58638e0.png)
 