### PR TITLE
Fixes issue #180 add settings 

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -61,6 +61,7 @@ const App = () => {
   const [searchResults, setSearchResults] = useState([]);
   const [searchTableViewMode, setSearchTableViewMode] = useState(false);
   const [showAboutUs, setShowAboutUs] = useState(!localStorage.getItem("returningUser"));
+  const [showSettings, setShowSettings] = useState(false);
 
   function skipSong() {
     const i = queue.findIndex((item) => item.qid === currentQid);
@@ -190,6 +191,8 @@ const App = () => {
               setSearchTableViewMode,
               setShowAboutUs,
               showAboutUs,
+              showSettings,
+              setShowSettings,
             }}
           />
         </Suspense>

--- a/frontend/src/components/AppBar/AppBar.js
+++ b/frontend/src/components/AppBar/AppBar.js
@@ -26,9 +26,9 @@ export default function QasongAppBar({
   handleSubmitMusicSearch,
   queue,
   darkMode,
-  setDarkMode,
   showAboutUs,
   setShowAboutUs,
+  setShowSettings,
 }) {
   const [scrollTop, setScrollTop] = useState(0);
 
@@ -84,10 +84,9 @@ export default function QasongAppBar({
           <Menu
             queueLength={queue.length}
             {...{
-              darkMode,
-              setDarkMode,
               showAboutUs,
               setShowAboutUs,
+              setShowSettings,
             }}
           />
         </Toolbar>

--- a/frontend/src/components/AppBar/Menu/Menu.js
+++ b/frontend/src/components/AppBar/Menu/Menu.js
@@ -13,7 +13,7 @@ const useStyles = makeStyles({
   },
 });
 
-function MobileMenu({ queueLength, darkMode, setDarkMode, setShowAboutUs }) {
+function MobileMenu({ queueLength, setShowAboutUs, setShowSettings }) {
   const classes = useStyles();
 
   let history = useHistory();
@@ -42,8 +42,9 @@ function MobileMenu({ queueLength, darkMode, setDarkMode, setShowAboutUs }) {
     history.push("/playlists");
   }
 
-  function handleDarkmodeButtonClick() {
-    setDarkMode(!darkMode);
+  function handleSettingsClick() {
+    setShowSettings(true);
+    history.push("/");
   }
 
   function handleAboutUsClick() {
@@ -81,13 +82,7 @@ function MobileMenu({ queueLength, darkMode, setDarkMode, setShowAboutUs }) {
         </MenuItem>
         <MenuItem onClick={handlePlaylistClick}>playlists</MenuItem>
         <MenuItem onClick={handleBillboardClick}>billboard top 100</MenuItem>
-
-        {/* dark mode */}
-        <MenuItem onClick={handleDarkmodeButtonClick}>
-          dark mode
-          <Switch checked={darkMode} />
-        </MenuItem>
-
+        <MenuItem onClick={handleSettingsClick}>settings</MenuItem>
         <MenuItem onClick={handleAboutUsClick}>about us</MenuItem>
       </Menu>
 

--- a/frontend/src/components/HomeScreen/HomeScreen.js
+++ b/frontend/src/components/HomeScreen/HomeScreen.js
@@ -2,6 +2,7 @@ import React, { Suspense } from "react";
 import { Box, Grid, Typography } from "@material-ui/core";
 import LoadingAnimation from "../LoadingAnimation/LoadingAnimation";
 import WelcomeWindow from "./WelcomeWindow/WelcomeWindow";
+import Settings from "./Settings/Settings";
 
 const FeaturedPlaylists = React.lazy(() =>
   import("./FeaturedPlaylists/FeaturedPlaylists")
@@ -16,6 +17,10 @@ function HomeScreen({
   addSongToQueue,
   showAboutUs,
   setShowAboutUs,
+  showSettings,
+  setShowSettings,
+  darkMode,
+  setDarkMode,
 }) {
   return (
     <Box mt={4}>
@@ -23,6 +28,15 @@ function HomeScreen({
         {...{
           showAboutUs,
           setShowAboutUs,
+        }}
+      />
+
+      <Settings
+        {...{
+          showSettings,
+          setShowSettings,
+          darkMode,
+          setDarkMode,
         }}
       />
 

--- a/frontend/src/components/HomeScreen/Settings/Settings.js
+++ b/frontend/src/components/HomeScreen/Settings/Settings.js
@@ -1,0 +1,106 @@
+import React from "react";
+import { makeStyles } from "@material-ui/core/styles";
+import { Dialog, Fade, Typography, Switch, FormControlLabel, Select, MenuItem, Grid } from "@material-ui/core";
+
+const useStyles = makeStyles((theme) => ({
+  modal: {
+    position: "absolute",
+    height: "100%",
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "center",
+    overflow: "hidden",
+  },
+  paper: {
+    backgroundColor: theme.palette.background.paper,
+    border: "2px solid #000",
+    boxShadow: theme.shadows[5],
+    padding: theme.spacing(2, 4, 3),
+  },
+  select: {
+    marginLeft: '20px',
+    minWidth: '75px'
+  }
+}));
+
+export default function TransitionsModal({ showSettings, setShowSettings,  darkMode, setDarkMode }) {
+  const classes = useStyles();
+
+  const handleClose = () => {
+    setShowSettings(false);
+  };
+
+  function handleDarkmodeButtonClick() {
+    setDarkMode(!darkMode);
+  }
+  
+  return (
+    <div>
+      <Dialog className={classes.modal} open={showSettings} onClose={handleClose}>
+        <Fade in={showSettings}>
+          <div className={classes.paper}>
+            <Typography gutterBottom variant="h4" align="center">
+              Settings
+            </Typography>
+
+            <Grid>
+              <Grid>
+                {/* dark mode */}
+                <FormControlLabel
+                  control={<Switch onChange={handleDarkmodeButtonClick} checked={darkMode} />}
+                  label="Dark Mode"
+                  labelPlacement="start"
+                />
+              </Grid>
+
+              <Grid>
+                <FormControlLabel
+                  label="Playback Speed"
+                  labelPlacement="start"
+                  control={
+                    <Select
+                      className={classes.select}
+                      defaultValue={1}
+                      // value={speed}
+                      // onChange={handleChange}
+                    >
+                      <MenuItem value={0.25}>0.25</MenuItem>
+                      <MenuItem value={0.50}>0.50</MenuItem>
+                      <MenuItem value={0.75}>0.75</MenuItem>
+                      <MenuItem value={1}>normal</MenuItem>
+                      <MenuItem value={1.25}>1.25</MenuItem>
+                      <MenuItem value={1.5}>1.5</MenuItem>
+                      <MenuItem value={1.75}>1.75</MenuItem>
+                      <MenuItem value={2}>2</MenuItem>
+                    </Select>
+                  }
+                />
+              </Grid>
+
+              <Grid>
+                <FormControlLabel
+                  label="Language"
+                  labelPlacement="start"
+                  control={
+                    <Select
+                      className={classes.select}
+                      defaultValue='english'
+                      // value={speed}
+                      // onChange={handleChange}
+                    >
+                      <MenuItem value='english'>english</MenuItem>
+                      <MenuItem value='spanish'>spanish</MenuItem>
+                      <MenuItem value='chinese'>chinese</MenuItem>
+                      <MenuItem value='french'>french</MenuItem>
+                    </Select>
+                  }
+                />
+              </Grid>
+            </Grid>
+
+          </div>
+        </Fade>
+      </Dialog>
+    </div>
+  );
+}

--- a/frontend/src/routes.js
+++ b/frontend/src/routes.js
@@ -30,6 +30,8 @@ function Routes({
   setSearchTableViewMode,
   setShowAboutUs,
   showAboutUs,
+  showSettings,
+  setShowSettings,
 }) {
   return (
     <Router>
@@ -39,9 +41,9 @@ function Routes({
             darkMode,
             handleSubmitMusicSearch,
             queue,
-            setDarkMode,
             showAboutUs,
             setShowAboutUs,
+            setShowSettings,
           }}
         />
       </Suspense>
@@ -108,6 +110,10 @@ function Routes({
                   addSongToQueue,
                   showAboutUs,
                   setShowAboutUs,
+                  showSettings,
+                  setShowSettings,
+                  darkMode,
+                  setDarkMode,
                 }}
               />
             </Suspense>


### PR DESCRIPTION
This put request resolves issue #180 

Add setting window, setting into menu app bar, move dark mode into settings, added language and playback speed in setting (no functionality)

To do this I added another react hook in app.js passed props down to new settings component. Added setting window and it displays when the menu button in the app bar. Moved darktheme code toggle from app bar to settings. Added language and playback speed as selects in settings without functionality. Factored out unnecessary darkmode/setDarkMode props that were passed to app bar/ menu (kept darkmode prop in darkmode because it is used for conditionally displaying qasong icon.

Images: 
![image](https://user-images.githubusercontent.com/58538645/101104417-0da33400-3599-11eb-80ee-402e47014a5a.png)
![image](https://user-images.githubusercontent.com/58538645/101104423-1136bb00-3599-11eb-9661-64e8086cb7da.png)
![image](https://user-images.githubusercontent.com/58538645/101104430-1431ab80-3599-11eb-9e99-7aca61983c75.png)

