### PR TITLE
Fixes #195 clearQueue button should produce a meterial-ui confirmation dialog rather than window confirm()

### DIFF
--- a/frontend/src/components/QueueSection/ClearButton/ClearButton.js
+++ b/frontend/src/components/QueueSection/ClearButton/ClearButton.js
@@ -1,23 +1,15 @@
 import React from "react";
 import DeleteOutlineIcon from "@material-ui/icons/DeleteOutline";
 import { IconButton, Box } from "@material-ui/core";
-import { clear } from "../../../functions";
+// import { clear } from "../../../functions";
 
-function ShareButton({ disabled, queue, setQueue }) {
-  function handleClick() {
-    let confirmClear = confirm("Are you sure you want to clear the queue?");
-    if (confirmClear) {
-      setQueue(clear(queue));
-    }
-  }
-
+function ShareButton({ disabled }) {
   return (
     <Box mt={1}>
       <IconButton
         edge="end"
         title="Clear the entire queue"
         disabled={disabled}
-        onClick={handleClick}
         target="_blank"
         color={disabled ? "inherit" : "secondary"}
       >

--- a/frontend/src/components/QueueSection/ClearButton/ClearButton.js
+++ b/frontend/src/components/QueueSection/ClearButton/ClearButton.js
@@ -1,7 +1,6 @@
 import React from "react";
 import DeleteOutlineIcon from "@material-ui/icons/DeleteOutline";
 import { IconButton, Box } from "@material-ui/core";
-// import { clear } from "../../../functions";
 
 function ShareButton({ disabled }) {
   return (

--- a/frontend/src/components/QueueSection/ConfirmClearDialog/ConfirmClearDialog.js
+++ b/frontend/src/components/QueueSection/ConfirmClearDialog/ConfirmClearDialog.js
@@ -1,0 +1,52 @@
+import React from "react";
+import { clear } from "../../../functions";
+import {
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  Typography,
+  Button,
+} from "@material-ui/core";
+
+function ConfirmClearDialog(props) {
+  const { queue, setQueue, confirmDialog, setConfirmDialog } = props;
+
+  function handleClickYes() {
+    setQueue(clear(queue));
+  }
+
+  function handleClickNo() {
+    setConfirmDialog({ ...confirmDialog, isOpen: false });
+  }
+
+  return (
+    <Dialog
+      open={confirmDialog.isOpen}
+      PaperProps={{ style: { backgroundColor: "orange", boxShadow: "none" } }}
+    >
+      <DialogTitle>
+        <Typography variant="h6" color="primary">
+          {confirmDialog.title}
+        </Typography>
+      </DialogTitle>
+
+      <DialogContent>
+        <Typography variant="subtitle2" color="primary">
+          {confirmDialog.subTitle}
+        </Typography>
+      </DialogContent>
+
+      <DialogActions>
+        <Button onClick={handleClickYes}>
+          <Typography color="primary"> Yes </Typography>
+        </Button>
+        <Button onClick={handleClickNo}>
+          <Typography color="primary"> No </Typography>
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}
+
+export default ConfirmClearDialog;

--- a/frontend/src/components/QueueSection/QueueSection.js
+++ b/frontend/src/components/QueueSection/QueueSection.js
@@ -9,6 +9,7 @@ import Alert from "@material-ui/lab/Alert";
 
 // material-ui
 import { IconButton, Typography, Box, Grid } from "@material-ui/core";
+
 import {
   Queue as QueueIcon,
   DragHandle as DragHandleIcon,
@@ -24,10 +25,16 @@ import PlayQueueButton from "./PlayQueueButton/PlayQueueButton";
 import ShuffleButton from "./ShuffleButton/ShuffleButton";
 import ClearButton from "./ClearButton/ClearButton";
 import SaveQueueButton from "./SaveQueueButton/SaveQueueButton";
+import ConfirmClearDialog from "./ConfirmClearDialog/ConfirmClearDialog";
 
 function QueueSection({ nowPlaying, setNowPlaying, queue, setQueue }) {
   const [displayMode, setDisplayMode] = useState("list");
   const [displaySaved, setDisplaySaved] = useState(false);
+  const [confirmDialog, setConfirmDialog] = useState({
+    isOpen: false,
+    title: "",
+    subTitle: "",
+  });
 
   const handleClickQueueItem = (qid) => {
     setNowPlaying(queue.find((item) => item.qid === qid));
@@ -143,7 +150,16 @@ function QueueSection({ nowPlaying, setNowPlaying, queue, setQueue }) {
           <Grid item onClick={handleClickSave}>
             <SaveQueueButton {...{ queue }} />
           </Grid>
-          <Grid item>
+          <Grid
+            item
+            onClick={() => {
+              setConfirmDialog({
+                isOpen: true,
+                title: "Are you sure you want to clear the queue?",
+                subTitle: "You can't undo this operation.",
+              });
+            }}
+          >
             <ClearButton {...{ setQueue }} />
           </Grid>
           {displaySaved ? (
@@ -154,6 +170,12 @@ function QueueSection({ nowPlaying, setNowPlaying, queue, setQueue }) {
             </Grid>
           ) : null}
         </Grid>
+        <ConfirmClearDialog
+          queue={queue}
+          setQueue={setQueue}
+          confirmDialog={confirmDialog}
+          setConfirmDialog={setConfirmDialog}
+        />
       </Box>
 
       <DndProvider backend={isMobile ? TouchBackend : HTML5Backend}>


### PR DESCRIPTION
Fixes #195, I have changed the default window confirm() dialog to the Material-UI based Dialog component.
![image](https://user-images.githubusercontent.com/54863160/101962459-38fdd280-3bda-11eb-92bd-46dc0dc4bb2b.png)
![image](https://user-images.githubusercontent.com/54863160/101962486-4d41cf80-3bda-11eb-9901-5ce6ffe51bf1.png)
- Selecting Yes will clear the queue and close the dialog.
- Selecting No will simply close the dialog without further operations.

Please let me know if you have any suggestions.